### PR TITLE
商品情報編集機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,6 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!  , except: [:index,:show]
+  before_action :set_item, only: [:show,:edit,:update]
 
   def index
     @items =Item.order(created_at: :desc)
@@ -19,11 +20,10 @@ class ItemsController < ApplicationController
   end
 
   def show
-    @item = Item.find(params[:id])
+   
   end
 
   def edit
-     @item = Item.find(params[:id])
 
     if @item.user == current_user
       render "edit"
@@ -33,11 +33,11 @@ class ItemsController < ApplicationController
   end
 
   def update
-    @item = Item.find(params[:id])
-    if @item.update(item_params)
+    
+    if @item.update(item_params) ||@item.user == current_user
       redirect_to item_path
     else
-      render :edit
+      render "edit"
     end
   end
 
@@ -48,5 +48,9 @@ class ItemsController < ApplicationController
 
   def item_params
     params.require(:item).permit(:image,:name,:introduction,:category_id,:condition_id,:payer_id,:area_id,:delivery_day_id,:price).merge(user_id: current_user.id)
+  end
+
+  def set_item
+    @item = Item.find(params[:id])
   end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,7 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!  , except: [:index,:show]
   before_action :set_item, only: [:show,:edit,:update]
+  before_action :current_item, only: [:edit,:update]
 
   def index
     @items =Item.order(created_at: :desc)
@@ -25,7 +26,7 @@ class ItemsController < ApplicationController
 
   def edit
 
-    if @item.user == current_user
+    if 
       render "edit"
     else
       redirect_to root_path
@@ -34,7 +35,7 @@ class ItemsController < ApplicationController
 
   def update
     
-    if @item.update(item_params) ||@item.user == current_user
+    if @item.update(item_params) 
       redirect_to item_path
     else
       render "edit"
@@ -52,5 +53,9 @@ class ItemsController < ApplicationController
 
   def set_item
     @item = Item.find(params[:id])
+  end
+
+  def current_item
+    @item.user == current_user
   end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -23,7 +23,13 @@ class ItemsController < ApplicationController
   end
 
   def edit
-     @item = Item.find(params[:id]) 
+     @item = Item.find(params[:id])
+
+    if @item.user == current_user
+      render "edit"
+    else
+      redirect_to root_path
+    end
   end
 
   def update

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,7 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!  , except: [:index,:show]
   before_action :set_item, only: [:show,:edit,:update]
-  before_action :current_item, only: [:edit,:update]
+  before_action :syori_item,only: [:edit,:update]
 
   def index
     @items =Item.order(created_at: :desc)
@@ -26,11 +26,6 @@ class ItemsController < ApplicationController
 
   def edit
 
-    if 
-      render "edit"
-    else
-      redirect_to root_path
-    end
   end
 
   def update
@@ -55,7 +50,9 @@ class ItemsController < ApplicationController
     @item = Item.find(params[:id])
   end
 
-  def current_item
-    @item.user == current_user
+  def syori_item
+    if current_user.id != @item.user.id
+     redirect_to root_path
+    end
   end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -22,6 +22,18 @@ class ItemsController < ApplicationController
     @item = Item.find(params[:id])
   end
 
+  def edit
+     @item = Item.find(params[:id]) 
+  end
+
+  def update
+    @item = Item.find(params[:id])
+    if @item.update(item_params)
+      redirect_to item_path
+    else
+      render :edit
+    end
+  end
 
 
 

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -10,11 +10,14 @@ class Item < ApplicationRecord
   belongs_to :user
   has_one_attached :image
 
+  validates :price,      format: { with: /\A[0-9]+\z/},
+  numericality: { only_integer: true,greater_than: 299, less_than: 10000000, message:"Out of setting range"}, allow_blank: true
+
   with_options presence: true do
   validates :image
   validates :name,            length:{maximum: 40}
   validates :introduction,    length:{maximum: 1000}
-  
+  validates :price
 
   with_options numericality: { other_than: 1, message:"Select"} do
   validates :category_id          
@@ -24,9 +27,8 @@ class Item < ApplicationRecord
   validates :delivery_day_id     
   end
 
-  validates :price,      format: { with: /\A[0-9]+\z/},
-  numericality: { only_integer: true,greater_than: 299, less_than: 10000000, message:"Out of setting range"}, allow_blank: true
- 
-  
+  #validates :price,      format: { with: /\A[0-9]+\z/},
+  #numericality: { only_integer: true,greater_than: 299, less_than: 10000000, message:"Out of setting range"}, allow_blank: true
+
   end
 end

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -1,0 +1,160 @@
+<%# cssは商品出品のものを併用しています。
+app/assets/stylesheets/items/new.css %>
+
+<div class="items-sell-contents">
+  <header class="items-sell-header">
+    <%= link_to image_tag('furima-logo-color.png' , size: '185x50'), "/" %>
+  </header>
+  <div class="items-sell-main">
+    <h2 class="items-sell-title">商品の情報を入力</h2>
+    <%= form_with  model: @item, local: true do |f| %>
+
+    <%= render  'items/error_messages', model: f.object %>
+
+
+    <%# 出品画像 %>
+    <div class="img-upload">
+      <div class="weight-bold-text">
+        出品画像
+        <span class="indispensable">必須</span>
+      </div>
+      <div class="click-upload">
+        <p>
+          クリックしてファイルをアップロード
+        </p>
+        <%= f.file_field :image, id:"item-image" %>
+      </div>
+    </div>
+    <%# /出品画像 %>
+    <%# 商品名と商品説明 %>
+    <div class="new-items">
+      <div class="weight-bold-text">
+        商品名
+        <span class="indispensable">必須</span>
+      </div>
+      <%= f.text_area :name, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
+      <div class="items-explain">
+        <div class="weight-bold-text">
+          商品の説明
+          <span class="indispensable">必須</span>
+        </div>
+        <%= f.text_area :introduction, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
+      </div>
+    </div>
+    <%# /商品名と商品説明 %>
+
+    <%# 商品の詳細 %>
+    <div class="items-detail">
+      <div class="weight-bold-text">商品の詳細</div>
+      <div class="form">
+        <div class="weight-bold-text">
+          カテゴリー
+          <span class="indispensable">必須</span>
+        </div>
+        <%= f.collection_select(:category_id, Category.all, :id, :name, {}, {class:"select-box", id:"item-category"}) %>
+        <div class="weight-bold-text">
+          商品の状態
+          <span class="indispensable">必須</span>
+        </div>
+        <%= f.collection_select(:condition_id, Condition.all, :id, :name, {}, {class:"select-box", id:"item-sales-status"}) %>
+      </div>
+    </div>
+    <%# /商品の詳細 %>
+
+    <%# 配送について %>
+    <div class="items-detail">
+      <div class="weight-bold-text question-text">
+        <span>配送について</span>
+        <a class="question" href="#">?</a>
+      </div>
+      <div class="form">
+        <div class="weight-bold-text">
+          配送料の負担
+          <span class="indispensable">必須</span>
+        </div>
+        <%= f.collection_select(:payer_id, Payer.all, :id, :name, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
+        <div class="weight-bold-text">
+          発送元の地域
+          <span class="indispensable">必須</span>
+        </div>
+        <%= f.collection_select(:area_id, Area.all, :id ,:name, {}, {class:"select-box", id:"item-prefecture"}) %>
+        <div class="weight-bold-text">
+          発送までの日数
+          <span class="indispensable">必須</span>
+        </div>
+        <%= f.collection_select(:delivery_day_id, DeliveryDay.all, :id, :name, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
+      </div>
+    </div>
+    <%# /配送について %>
+
+    <%# 販売価格 %>
+    <div class="sell-price">
+      <div class="weight-bold-text question-text">
+        <span>販売価格<br>(¥300〜9,999,999)</span>
+        <a class="question" href="#">?</a>
+      </div>
+      <div>
+        <div class="price-content">
+          <div class="price-text">
+            <span>価格</span>
+            <span class="indispensable">必須</span>
+          </div>
+          <span class="sell-yen">¥</span>
+          <%= f.text_field :price, class:"price-input", id:"item-price", placeholder:"例）300" %>
+        </div>
+        <div class="price-content">
+          <span>販売手数料 (10%)</span>
+          <span>
+            <span id='add-tax-price'></span>円
+          </span>
+        </div>
+        <div class="price-content">
+          <span>販売利益</span>
+          <span>
+            <span id='profit'></span>円
+          </span>
+        </div>
+      </div>
+    </div>
+    <%# /販売価格 %>
+
+    <%# 注意書き %>
+    <div class="caution">
+      <p class="sentence">
+        <a href="#">禁止されている出品、</a>
+        <a href="#">行為</a>
+        を必ずご確認ください。
+      </p>
+      <p class="sentence">
+        またブランド品でシリアルナンバー等がある場合はご記載ください。
+        <a href="#">偽ブランドの販売</a>
+        は犯罪であり処罰される可能性があります。
+      </p>
+      <p class="sentence">
+        また、出品をもちまして
+        <a href="#">加盟店規約</a>
+        に同意したことになります。
+      </p>
+    </div>
+    <%# /注意書き %>
+    <%# 下部ボタン %>
+    <div class="sell-btn-contents">
+      <%= f.submit "変更する" ,class:"sell-btn" %>
+      <%=link_to 'もどる', "#", class:"back-btn" %>
+    </div>
+    <%# /下部ボタン %>
+  </div>
+  <% end %>
+
+  <footer class="items-sell-footer">
+    <ul class="menu">
+      <li><a href="#">プライバシーポリシー</a></li>
+      <li><a href="#">フリマ利用規約</a></li>
+      <li><a href="#">特定商取引に関する表記</a></li>
+    </ul>
+    <%= link_to image_tag('furima-logo-color.png' , size: '185x50'), "/" %>
+    <p class="inc">
+      ©︎Furima,Inc.
+    </p>
+  </footer>
+</div>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -26,7 +26,7 @@
 
    <%if user_signed_in?%>
    <% if current_user.id == @item.user_id %>
-    <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
+    <%= link_to "商品の編集", edit_item_path(@item.id), method: :get, class: "item-red-btn" %>
     <p class="or-text">or</p>
     <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
    

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: 'items#index'
-  resources :items, only: [:new, :create,:show] 
+  resources :items, only: [:new, :create,:show,:edit,:update] 
 
 end


### PR DESCRIPTION
# What
投稿者のみ商品編集ページへの遷移と
投稿内容の変更が可能

# Why
商品情報編集を実装するため

【gif】
ログイン状態の出品者は、商品情報編集ページに遷移できる動画
https://gyazo.com/5e0f018e75eb9559327c329d896ab240

正しく情報を記入すると、商品の情報を編集できる動画
https://gyazo.com/35158deb81812d2aff41c1b9cedb91fd

入力に問題のある状態では商品の情報は編集できず、エラーメッセージが出力される動画
https://gyazo.com/f654458a26e40c45d490b7a79f0deec3

何も編集せずに更新をしても画像無しの商品にならない動画
https://gyazo.com/a4ab367966494462b2bb5cb4887a19c1

ログイン状態のユーザーであっても、URLを直接入力して出品していない商品の商品情報編集ページへ遷移しようとすると、トップページに遷移する動画
https://gyazo.com/2aef71945205b2e176dde47b085ebaad

ログアウト状態のユーザーは、URLを直接入力して商品情報編集ページへ遷移しようとすると、ログインページに遷移する動画
https://gyazo.com/dcd256596c85ac08f25743a3d052d5e5

商品名やカテゴリーの情報など、すでに登録されている商品情報は商品情報編集画面を開いた時点で表示される動画（画像に関しては、表示されない状態で良い）
https://gyazo.com/668cd1a282f9199a755813784fe6cf30

